### PR TITLE
Provide default for `otter dev --port`

### DIFF
--- a/cmd/otter/dev.go
+++ b/cmd/otter/dev.go
@@ -27,7 +27,12 @@ var devCmd = &cobra.Command{
 	Short: "Runs a dev server",
 	Long:  `Run a dev server that will auto-compile templ files into go and restart the go server. It will also create a proxy to auto-reload the browser on changes.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		port := env.RequiredIntEnvVar("PORT")
+		port := env.OptionalIntEnvVar("PORT", 0)
+		if port == 0 {
+			portFlag, err := cmd.Flags().GetInt64("port")
+			cobra.CheckErr(err)
+			port = portFlag
+		}
 		actualPort := port - 1
 
 		verbose, _ := cmd.Flags().GetBool("verbose")
@@ -70,6 +75,7 @@ var devCmd = &cobra.Command{
 
 func init() {
 	devCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
+	devCmd.Flags().Int64P("port", "p", 8000, "Development server port")
 }
 
 func runTemplProxy(ctx context.Context, logger *slog.Logger, port int64, actualPort int64) {


### PR DESCRIPTION
This pull request adds the `otter dev --port` command-line option and provides a default value (8000), as the previous user experience for `otter dev` was a bit surprising:

```
2024/11/18 17:36:03 ERROR missing required int for env variable `PORT`
```

Now you can either rely on the default value, use e.g. `otter dev --port 3000`, or keep using the `PORT` environment variable to override the option's value.

<sub>And ports should be `uint16` rather than `int64` but [when in Rome, do as the Romans do](https://en.wikipedia.org/wiki/When_in_Rome,_do_as_the_Romans_do)... at least for now. 😈 </sub>